### PR TITLE
chore: Add GitHub Actions workflow to manually trigger Dependabot updates

### DIFF
--- a/.github/workflows/trigger-dependabot.yml
+++ b/.github/workflows/trigger-dependabot.yml
@@ -1,0 +1,14 @@
+name: Trigger Dependabot
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Dependabot
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/dependabot/updates


### PR DESCRIPTION
Add a new GitHub Actions workflow to manually trigger Dependabot updates.

* Create a new file `.github/workflows/trigger-dependabot.yml`.
* Define a workflow named "Trigger Dependabot" with `workflow_dispatch` event to allow manual triggering.
* Add a job named `trigger-dependabot` that runs on `ubuntu-latest`.
* Include a step to trigger Dependabot updates using a `curl` command with the GitHub API.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/azman0101/images_tools/pull/78?shareId=4957f9a0-58c8-453a-b006-24a8f9ecfe5f).