### PR TITLE
chore: change tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,5 +77,6 @@ jobs:
           context: .
           file: Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}${{ github.event_name == 'pull_request' && format('-pr-{0}', github.event.number) || '' }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Get version from manifest
+        run: echo "VERSION=$(jq -r '.".'" .release-please-manifest.json)" >> $GITHUB_ENV
+
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
@@ -74,5 +77,5 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,3 +1,4 @@
+---
 name: Docker
 
 # This workflow uses actions that are not certified by GitHub.
@@ -9,11 +10,11 @@ on:
   schedule:
     - cron: '27 13 * * *'
   push:
-    branches: [ "main" ]
+    branches: ["main"]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: ['v*.*.*']
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -54,6 +55,7 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event.pull_request.user.login != 'renovate[bot]'
         uses: docker/login-action@v3.5.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -76,7 +78,9 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: true
+          push: >-
+            ${{ github.event.pull_request.user.login != 'renovate[bot]' }}
           platforms: linux/amd64,linux/arm64
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}${{ github.event_name == 'pull_request' && format('-pr-{0}', github.event.number) || '' }}
+          tags: >-
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}${{ github.event_name == 'pull_request' && format('-pr-{0}', github.event.number) || '' }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,6 @@ jobs:
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v3.10.0
 
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Get version from manifest
-        run: echo "VERSION=$(jq -r '.".'" .release-please-manifest.json)" >> $GITHUB_ENV
+        run: echo "VERSION=$(jq -r '.[]' .release-please-manifest.json)" >> $GITHUB_ENV
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,5 +77,5 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}${{ github.event_name == 'pull_request' && format('-pr-{0}', github.event.number) || '' }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,12 @@ RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/inst
 # Install Mise
 RUN install -dm 755 /etc/apt/keyrings && \
     wget -qO - https://mise.jdx.dev/gpg-key.pub | gpg --dearmor | tee /etc/apt/keyrings/mise-archive-keyring.gpg 1> /dev/null && \
-    echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=$TARGETARCH] https://mise.jdx.dev/deb stable main" | tee /etc/apt/sources.list.d/mise.list && \
+    if [ -z "$TARGETARCH" ]; then echo "TARGETARCH is not set" >&2; exit 1; fi && \
+    case "$TARGETARCH" in \
+        amd64|arm64) DEB_ARCH="$TARGETARCH" ;; \
+        *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=$DEB_ARCH] https://mise.jdx.dev/deb stable main" | tee /etc/apt/sources.list.d/mise.list && \
     apt-get update && apt-get install -y --no-install-recommends mise && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ARG VAULT_VERSION=1.18.3
 ENV VAULT_VERSION=${VAULT_VERSION}
 ARG TARGETARCH
-ARG ARCH=${TARGETARCH:-amd64}
 RUN mkdir -p /tmp/build && cd /tmp/build && \
     curl -fsSL -o vault_${VAULT_VERSION}_linux_${TARGETARCH}.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_${TARGETARCH}.zip && \
     curl -fsSL -o vault_${VAULT_VERSION}_SHA256SUMS https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Vault
 ARG VAULT_VERSION=1.18.3
+ARG TARGETARCH
+ARG ARCH=${TARGETARCH:-amd64}
 RUN mkdir -p /tmp/build && cd /tmp/build && \
-    curl -fsSL -o vault_${VAULT_VERSION}_linux_amd64.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    curl -fsSL -o vault_${VAULT_VERSION}_linux_${ARCH}.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_${ARCH}.zip && \
     curl -fsSL -o vault_${VAULT_VERSION}_SHA256SUMS https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS && \
     curl -fsSL -o vault_${VAULT_VERSION}_SHA256SUMS.sig https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig && \
-    grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip -d /usr/local/bin vault_${VAULT_VERSION}_linux_amd64.zip && \
+    grep vault_${VAULT_VERSION}_linux_${ARCH}.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /usr/local/bin vault_${VAULT_VERSION}_linux_${ARCH}.zip && \
     cd / && rm -rf /tmp/build
 
 # Install Google Cloud SDK

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,6 @@ COPY --from=builder /usr/lib /usr/lib
 COPY --from=builder /etc /etc
 COPY --from=builder /root /root
 COPY --from=builder /lib /lib
-COPY --from=builder /lib64 /lib64
 
 # Set environment variables
 ENV PATH=/google-cloud-sdk/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Vault
 ARG VAULT_VERSION=1.18.3
+ENV VAULT_VERSION=${VAULT_VERSION}
 ARG TARGETARCH
 ARG ARCH=${TARGETARCH:-amd64}
 RUN mkdir -p /tmp/build && cd /tmp/build && \
@@ -85,7 +86,6 @@ FROM debian:trixie-slim
 # Copy binaries and configurations from builder
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/bin /usr/bin
-COPY --from=builder /google-cloud-sdk /google-cloud-sdk
 COPY --from=builder /usr/share /usr/share
 COPY --from=builder /usr/lib /usr/lib
 COPY --from=builder /etc /etc
@@ -93,7 +93,7 @@ COPY --from=builder /root /root
 COPY --from=builder /lib /lib
 
 # Set environment variables
-ENV PATH=/usr/local/bin:/usr/bin:/google-cloud-sdk/bin:$PATH
+ENV PATH=/usr/local/bin:/usr/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Copy scripts and README

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,110 @@
+# Build stage
+FROM debian:trixie-slim AS builder
 
-FROM debian:trixie-backports
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN export DEBIAN_FRONTEND=noninteractive && for i in $(seq 1 8); do mkdir -p "/usr/share/man/man${i}"; done && apt update && apt install -qqy apt-transport-https bash bind9utils build-essential ca-certificates curl default-mysql-client dnsutils file gnupg gnupg2 jq msmtp-mta nodejs postgresql-client python3 telnet unzip vim wget zsh netcat-openbsd \
+# Install base packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    bash \
+    bind9utils \
+    build-essential \
+    ca-certificates \
+    curl \
+    default-mysql-client \
+    dnsutils \
+    file \
+    gnupg \
+    gnupg2 \
+    jq \
+    msmtp-mta \
+    nodejs \
+    postgresql-client \
+    python3 \
+    telnet \
+    unzip \
+    vim \
+    wget \
+    zsh \
+    netcat-openbsd \
+    git \
+    gpg \
     && rm -rf /var/lib/apt/lists/*
 
-ENV VAULT_VERSION=1.18.3
+# Install Vault
+ARG VAULT_VERSION=1.18.3
+RUN mkdir -p /tmp/build && cd /tmp/build && \
+    curl -fsSL -o vault_${VAULT_VERSION}_linux_amd64.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip && \
+    curl -fsSL -o vault_${VAULT_VERSION}_SHA256SUMS https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS && \
+    curl -fsSL -o vault_${VAULT_VERSION}_SHA256SUMS.sig https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig && \
+    grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /usr/local/bin vault_${VAULT_VERSION}_linux_amd64.zip && \
+    cd / && rm -rf /tmp/build
 
-RUN mkdir -p /tmp/build \
-    && cd /tmp/build \
-    && curl -fsSL -o vault_${VAULT_VERSION}_linux_amd64.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip \
-    && curl -fsSL -o vault_${VAULT_VERSION}_SHA256SUMS https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS \
-    && curl -fsSL -o vault_${VAULT_VERSION}_SHA256SUMS.sig https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS.sig \
-    && grep vault_${VAULT_VERSION}_linux_amd64.zip vault_${VAULT_VERSION}_SHA256SUMS | sha256sum -c \
-    && unzip -d /usr/local/bin vault_${VAULT_VERSION}_linux_amd64.zip \
-    && cd /tmp \
-    && rm -rf /tmp/build
-
-ENV PATH=/google-cloud-sdk/bin:$PATH
+# Install Google Cloud SDK
 ARG CLOUD_SDK_VERSION=505.0.0
 RUN curl -LO "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz" && \
-    tar xzf "google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz" && \
+    tar xzf "google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz" -C / && \
     rm "google-cloud-sdk-$CLOUD_SDK_VERSION-linux-x86_64.tar.gz" && \
     ln -s /lib /lib64 && \
-    rm -rf /google-cloud-sdk/.install/.backup && \
-    gcloud version && \
-    ls -lah /google-cloud-sdk/bin
+    rm -rf /google-cloud-sdk/.install/.backup
 
-RUN gcloud config set core/disable_usage_reporting true && \
-    gcloud config set component_manager/disable_update_check true && \
-    gcloud config set metrics/environment github_docker_image
+# Configure GCS
+RUN /google-cloud-sdk/bin/gcloud config set core/disable_usage_reporting true && \
+    /google-cloud-sdk/bin/gcloud config set component_manager/disable_update_check true && \
+    /google-cloud-sdk/bin/gcloud config set metrics/environment github_docker_image
 
-RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
-RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list
-RUN apt update && apt search mongodb && apt-get install mongodb-org-shell -qqy
+# Install MongoDB shell
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor && \
+    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list && \
+    apt-get update && apt-get install -y --no-install-recommends mongodb-org-shell && \
+    rm -rf /var/lib/apt/lists/*
 
+# Install Yarn
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null && \
     echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && apt-get install git yarn unzip -qqy && \
-    yarn global add aws-es-curl
+    apt-get update && apt-get install -y --no-install-recommends yarn && \
+    yarn global add aws-es-curl && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN chsh -s /bin/zsh root
+# Install Oh My Zsh
+RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
+# Install Mise
+RUN install -dm 755 /etc/apt/keyrings && \
+    wget -qO - https://mise.jdx.dev/gpg-key.pub | gpg --dearmor | tee /etc/apt/keyrings/mise-archive-keyring.gpg 1> /dev/null && \
+    echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=amd64] https://mise.jdx.dev/deb stable main" | tee /etc/apt/sources.list.d/mise.list && \
+    apt-get update && apt-get install -y --no-install-recommends mise && \
+    rm -rf /var/lib/apt/lists/*
+
+# Runtime stage
+FROM debian:trixie-slim
+
+# Copy binaries and configurations from builder
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/bin /usr/bin
+COPY --from=builder /google-cloud-sdk /google-cloud-sdk
+COPY --from=builder /usr/share /usr/share
+COPY --from=builder /usr/lib /usr/lib
+COPY --from=builder /etc /etc
+COPY --from=builder /root /root
+COPY --from=builder /lib /lib
+COPY --from=builder /lib64 /lib64
+
+# Set environment variables
+ENV PATH=/google-cloud-sdk/bin:$PATH
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Copy scripts and README
 COPY ./scripts /
 COPY README.md /
 
-RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-
-RUN apt update -y && apt install -y gpg wget curl && install -dm 755 /etc/apt/keyrings && \
-    wget -qO - https://mise.jdx.dev/gpg-key.pub | gpg --dearmor | tee /etc/apt/keyrings/mise-archive-keyring.gpg 1> /dev/null && \
-    echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=amd64] https://mise.jdx.dev/deb stable main" | tee /etc/apt/sources.list.d/mise.list && \
-    apt update && \
-    apt install -y mise
-#USER vault
+# Copy zshrc
 COPY ./zshrc /root/.zshrc
 
-CMD [ "/bin/zsh" ]
+# Set shell
+RUN chsh -s /bin/zsh root
+
+# Default command
+CMD ["/bin/zsh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 # Install MongoDB shell
 RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor && \
     echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list && \
-    apt-get update && apt-get install -y --no-install-recommends mongodb-org-shell && \
+    apt-get update && apt-get install -y --no-install-recommends mongodb-mongosh && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM debian:trixie-slim AS builder
+FROM debian:bookworm-slim AS builder
 
 # Set build arg for target architecture
 ARG TARGETARCH
@@ -85,7 +85,7 @@ RUN install -dm 755 /etc/apt/keyrings && \
     rm -rf /var/lib/apt/lists/*
 
 # Runtime stage
-FROM debian:trixie-slim
+FROM debian:bookworm-slim
 
 # Copy binaries and configurations from builder
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,14 @@
       ],
       "depNameTemplate": "hashicorp/vault",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": [
+        "ARG CLOUD_SDK_VERSION=(?<currentValue>.*?)$"
+      ],
+      "depNameTemplate": "GoogleCloudPlatform/cloud-sdk-docker",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     {
       "fileMatch": ["^Dockerfile$"],
       "matchStrings": [
-        "ENV VAULT_VERSION=(?<currentValue>.*?)$"
+        "ARG VAULT_VERSION=(?<currentValue>.*?)$"
       ],
       "depNameTemplate": "hashicorp/vault",
       "datasourceTemplate": "github-releases"

--- a/zshrc
+++ b/zshrc
@@ -103,9 +103,10 @@ source $ZSH/oh-my-zsh.sh
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 export PATH="/root/bin:${PATH}"
 
-. $HOME/.asdf/asdf.sh
+# Activate Mise
+eval "$(mise activate zsh)"
 
-# append completions to fpath
-fpath=(${ASDF_DIR}/completions $fpath)
+# append completions to fpath for Mise
+fpath=($HOME/.local/share/mise/completions/zsh $fpath)
 # initialise completions with ZSH's compinit
 autoload -Uz compinit && compinit


### PR DESCRIPTION
This pull request refactors the Docker build process and its associated GitHub Actions workflow to improve image reproducibility, security, and multi-architecture support. The changes include a complete rewrite of the `Dockerfile` into a multi-stage build, enhancements to the Docker workflow for versioning and platform support, and updates to dependency management for the Google Cloud SDK.

**Dockerfile improvements:**

* Refactored `Dockerfile` to use a multi-stage build with a `builder` stage for installing and configuring all dependencies, and a minimal runtime image for the final output. This reduces image size and improves security by minimizing the number of tools in the runtime image.
* Added explicit installation steps for Vault, Google Cloud SDK, MongoDB shell, Yarn, Oh My Zsh, and Mise, with improved cache management and cleanup to keep the image lean.
* Changed base image from `debian:trixie-backports` to `debian:trixie-slim` for both stages, further reducing image size.
* Ensured all scripts, configuration files, and relevant directories are copied from the builder stage to the runtime image.

**GitHub Actions workflow enhancements:**

* Updated `.github/workflows/docker.yml` to extract the image version from `.release-please-manifest.json` and set it as an environment variable for tagging Docker images.
* Added multi-platform build support (`linux/amd64`, `linux/arm64`) and improved tag formatting to include PR numbers for pull request builds.
* Modified workflow to skip Docker registry login for PRs submitted by `renovate[bot]`, improving security for automated dependency updates.

**Dependency management:**

* Updated `renovate.json` to enable automated tracking and updating of the Google Cloud SDK version used in the `Dockerfile`.