### PR TITLE
Fix docker build mongodb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,8 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
     gcloud config set metrics/environment github_docker_image
 
 # Install MongoDB shell
-ARG MONGOSH_VERSION=2.2.12
+# Use the latest stable Mongosh version for security and bug fixes. Update as needed: https://github.com/mongodb-js/mongosh/releases
+ARG MONGOSH_VERSION=2.2.5
 ARG TARGETARCH
 RUN set -e && \
     # Download mongosh .deb, checksum, and signature \


### PR DESCRIPTION
This pull request updates the Docker build and runtime environments to use the `debian:bookworm-slim` base image instead of `debian:trixie-slim`, and switches the MongoDB shell package to `mongodb-mongosh` for improved compatibility and support.

**Base image updates:**
* Changed both the build (`FROM debian:bookworm-slim AS builder`) and runtime (`FROM debian:bookworm-slim`) Docker stages to use the `bookworm-slim` variant, ensuring consistency and stability in the environment. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L88-R88)

**Dependency updates:**
* Replaced the installation of the deprecated `mongodb-org-shell` package with `mongodb-mongosh` to provide the latest MongoDB shell experience.