### PR TITLE
Fix mongodb shell package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
 # Install MongoDB shell
 RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor && \
     echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list && \
-    apt-get update && apt-get install -y --no-install-recommends mongodb-org-shell && \
+    apt-get update && apt-get install -y --no-install-recommends mongodb-mongosh && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Yarn


### PR DESCRIPTION
This pull request makes a small update to the Dockerfile to change which MongoDB shell package is installed. Instead of installing the legacy `mongodb-org-shell`, it now installs the newer `mongodb-mongosh` package.

- Updated the MongoDB shell installation step in the `Dockerfile` to use `mongodb-mongosh` instead of `mongodb-org-shell`, aligning with the latest MongoDB shell tooling.